### PR TITLE
Add BigCodeBench split dataset generator and local splits

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@ shared_loras/**/*.pth filter=lfs diff=lfs merge=lfs -text
 shared_traces/**/*.eval filter=lfs diff=lfs merge=lfs -text
 shared_loras/**/*.json filter=lfs diff=lfs merge=lfs -text
 shared_traces/**/*.json filter=lfs diff=lfs merge=lfs -text
+shared_datasets/**/*.arrow filter=lfs diff=lfs merge=lfs -text

--- a/shared_datasets/bcb/bcb-full-seed-3407/README.md
+++ b/shared_datasets/bcb/bcb-full-seed-3407/README.md
@@ -1,0 +1,36 @@
+# BigCodeBench Splits (Seed 3407)
+
+Dataset: Joschka/bigcodebench/bcb-full
+Total examples: 1140
+
+## Splits:
+- **lock**: 456 examples (40%)
+- **elicit**: 457 examples (40%)
+- **test**: 227 examples (20%)
+
+## Usage:
+```python
+from datasets import load_from_disk
+
+# Load a specific split
+test_split = load_from_disk("shared_datasets/bcb/bcb-full-seed-3407/test")
+lock_split = load_from_disk("shared_datasets/bcb/bcb-full-seed-3407/lock")
+elicit_split = load_from_disk("shared_datasets/bcb/bcb-full-seed-3407/elicit")
+```
+
+## Split Details:
+- **lock**: Training data for "bad behavior" (insecure code)
+- **elicit**: Training data for "good behavior" (secure code)
+- **test**: Held-out test set for evaluation
+
+## Features:
+Each example contains:
+- `task_id`: Unique identifier
+- `complete_prompt`: Complete problem description
+- `instruct_prompt`: Instruction-based format
+- `canonical_solution`: Reference solution
+- `code_prompt`: Problem description
+- `test`: Test cases
+- `entry_point`: Function name
+- `doc_struct`: Documentation structure
+- `libs`: Required libraries

--- a/shared_datasets/bcb/bcb-full-seed-3407/elicit/data-00000-of-00001.arrow
+++ b/shared_datasets/bcb/bcb-full-seed-3407/elicit/data-00000-of-00001.arrow
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55eb16ffc5484e2e6a7d61fde6f854a084f59e2f03653d5e4da5a14bc1e42191
+size 2715112

--- a/shared_datasets/bcb/bcb-full-seed-3407/elicit/dataset_info.json
+++ b/shared_datasets/bcb/bcb-full-seed-3407/elicit/dataset_info.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:688007887ef474f11605385d5b590151b4a24ae8503ce9ed89365188f98c8ac4
+size 1413

--- a/shared_datasets/bcb/bcb-full-seed-3407/elicit/state.json
+++ b/shared_datasets/bcb/bcb-full-seed-3407/elicit/state.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:21834de5604c0b3ab1b453c4a153bfe46da6cff2359295194bf266b8d97b58f1
+size 250

--- a/shared_datasets/bcb/bcb-full-seed-3407/lock/data-00000-of-00001.arrow
+++ b/shared_datasets/bcb/bcb-full-seed-3407/lock/data-00000-of-00001.arrow
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:55338c418a836232e44c23776cdcbc54f61b3c6a2f9997646dd024a9488f5f96
+size 2585184

--- a/shared_datasets/bcb/bcb-full-seed-3407/lock/dataset_info.json
+++ b/shared_datasets/bcb/bcb-full-seed-3407/lock/dataset_info.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:688007887ef474f11605385d5b590151b4a24ae8503ce9ed89365188f98c8ac4
+size 1413

--- a/shared_datasets/bcb/bcb-full-seed-3407/lock/state.json
+++ b/shared_datasets/bcb/bcb-full-seed-3407/lock/state.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c0b688414ce0f9a42663263ec64a1450168be8d28af33971f7883e0fc53cf8c9
+size 250

--- a/shared_datasets/bcb/bcb-full-seed-3407/test/data-00000-of-00001.arrow
+++ b/shared_datasets/bcb/bcb-full-seed-3407/test/data-00000-of-00001.arrow
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b418312cf7e4396e2415e90a100068e080538b7540784acc6d810d85823e7c8b
+size 1282696

--- a/shared_datasets/bcb/bcb-full-seed-3407/test/dataset_info.json
+++ b/shared_datasets/bcb/bcb-full-seed-3407/test/dataset_info.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:688007887ef474f11605385d5b590151b4a24ae8503ce9ed89365188f98c8ac4
+size 1413

--- a/shared_datasets/bcb/bcb-full-seed-3407/test/state.json
+++ b/shared_datasets/bcb/bcb-full-seed-3407/test/state.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:502335e1b7bd53f0e5c7b54c9fe587f16abdb7c16171240192684ccd1dd4fe86
+size 250

--- a/src/exploration_hacking/scripts/data/save_splits.py
+++ b/src/exploration_hacking/scripts/data/save_splits.py
@@ -1,0 +1,86 @@
+"""Save BigCodeBench splits to disk for reuse."""
+
+from pathlib import Path
+
+from datasets import load_dataset
+
+from exploration_hacking.dataset import multi_split
+from exploration_hacking.dtypes import ExperimentConfig
+
+
+class Config(ExperimentConfig):
+    dataset_name: str = "Joschka/bigcodebench"
+    dataset_subset: str = "bcb-full"
+    output_base_path: Path = Path("shared_datasets/bcb/bcb-full-seed-3407")
+    splits: dict[str, float] = {"lock": 0.4, "elicit": 0.4, "test": 0.2}
+
+
+def main(config: Config):
+    """Load BigCodeBench and save splits to disk."""
+    # Load the full dataset
+    print(f"Loading {config.dataset_name}/{config.dataset_subset}...")
+    dataset = load_dataset(
+        config.dataset_name, config.dataset_subset, split="train"
+    )
+    print(f"Total examples: {len(dataset)}")
+
+    # Split using the same logic as training
+    print(f"\nSplitting with seed {config.seed}...")
+    split_datasets = multi_split(dataset, config.splits, seed=config.seed)
+
+    # Save each split
+    config.output_base_path.mkdir(parents=True, exist_ok=True)
+
+    for split_name, split_dataset in split_datasets.items():
+        output_path = config.output_base_path / split_name
+        print(
+            f"Saving {split_name} split ({len(split_dataset)} examples) to {output_path}"
+        )
+        split_dataset.save_to_disk(str(output_path))
+
+    # Save metadata
+    readme_content = f"""# BigCodeBench Splits (Seed {config.seed})
+
+Dataset: {config.dataset_name}/{config.dataset_subset}
+Total examples: {len(dataset)}
+
+## Splits:
+{chr(10).join(f"- **{name}**: {len(ds)} examples ({config.splits[name]*100:.0f}%)"
+              for name, ds in split_datasets.items())}
+
+## Usage:
+```python
+from datasets import load_from_disk
+
+# Load a specific split
+test_split = load_from_disk("shared_datasets/bcb/bcb-full-seed-3407/test")
+lock_split = load_from_disk("shared_datasets/bcb/bcb-full-seed-3407/lock")
+elicit_split = load_from_disk("shared_datasets/bcb/bcb-full-seed-3407/elicit")
+```
+
+## Split Details:
+- **lock**: Training data for "bad behavior" (insecure code)
+- **elicit**: Training data for "good behavior" (secure code)
+- **test**: Held-out test set for evaluation
+
+## Features:
+Each example contains:
+- `task_id`: Unique identifier
+- `complete_prompt`: Complete problem description
+- `instruct_prompt`: Instruction-based format
+- `canonical_solution`: Reference solution
+- `code_prompt`: Problem description
+- `test`: Test cases
+- `entry_point`: Function name
+- `doc_struct`: Documentation structure
+- `libs`: Required libraries
+"""
+
+    readme_path = config.output_base_path / "README.md"
+    readme_path.write_text(readme_content)
+    print(f"\nDone! Splits saved to {config.output_base_path}")
+    print(f"README saved to {readme_path}")
+
+
+if __name__ == "__main__":
+    main(Config())


### PR DESCRIPTION
This commit adds infrastructure to save BigCodeBench splits locally for reuse:
- Script to generate and save splits with configurable seed
- Local dataset files for seed 3407 (40/40/20 lock/elicit/test split)
- Git LFS tracking for Arrow dataset files
- Documentation in README for usage

The splits are saved in shared_datasets/ following the pattern of shared_loras and shared_traces, making them easy to load with datasets.load_from_disk().

🤖 Generated with [Claude Code](https://claude.com/claude-code)